### PR TITLE
revert support to python 3.10-3.12

### DIFF
--- a/.github/workflows/release-tagged-image.yml
+++ b/.github/workflows/release-tagged-image.yml
@@ -13,7 +13,7 @@ jobs:
   pylint:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
     uses: ./.github/workflows/define-pylint.yml
     with:
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
aiohttp (and propably many other packages) dno't support 3.13