### PR TITLE
Speed up CI job

### DIFF
--- a/.github/workflows/define-build-image.yml
+++ b/.github/workflows/define-build-image.yml
@@ -2,6 +2,11 @@ name: Build image
 
 on:
   workflow_call:
+    inputs:
+      upload:
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -25,6 +30,7 @@ jobs:
         tags: ${{ env.IMAGE_NAME }}:latest
         outputs: type=docker,dest=/tmp/image.tar
     - name: Upload image artifact
+      if: ${{ inputs.upload == true }}
       uses: actions/upload-artifact@v4
       with:
         name: image

--- a/.github/workflows/release-tagged-image.yml
+++ b/.github/workflows/release-tagged-image.yml
@@ -22,6 +22,8 @@ jobs:
   build:
     needs: [pylint]
     uses: ./.github/workflows/define-build-image.yml
+    with:
+      upload: true
     secrets: inherit
 
   tag:


### PR DESCRIPTION
Speed up the CI job by skipping uploading the built image if it is not a release