### PR TITLE
Storage rework

### DIFF
--- a/src/nikobot/modules/mal/malnotifier.py
+++ b/src/nikobot/modules/mal/malnotifier.py
@@ -50,7 +50,7 @@ class MALNotifier(commands.Cog):
         manga = None
 
         user_id = util.discord.get_user_id(ctx)
-        if util.VolatileStorage.exists(f"mal.user.{user_id}"):
+        if util.VolatileStorage.contains(f"mal.user.{user_id}"):
             maluser: MALUser = util.VolatileStorage[f"mal.user.{user_id}"]
             maluser.fetch_manga_list()
             if mal_id in maluser.manga:
@@ -81,7 +81,7 @@ class MALNotifier(commands.Cog):
 
         user_id = util.discord.get_user_id(ctx)
 
-        if util.VolatileStorage.contains("mal.user", str(user_id)):
+        if util.VolatileStorage.contains(f"mal.user.{user_id}"):
             await util.discord.reply(ctx, embed=discord.Embed(title="You are already registered",
                                                               color=discord.Color.orange()))
             return
@@ -122,7 +122,7 @@ class MALNotifier(commands.Cog):
         else:
             user_id = ctx.author.id
 
-        if not util.VolatileStorage.contains("mal.user", str(user_id)):
+        if not util.VolatileStorage.contains(f"mal.user.{user_id}"):
             await util.discord.reply(ctx,
                                      embed=discord.Embed(title="You are not yet registered",
                                                          color=discord.Color.orange()))
@@ -146,7 +146,7 @@ class MALNotifier(commands.Cog):
         else:
             user_id = ctx.author.id
 
-        if not util.VolatileStorage.contains("mal.user", str(user_id)):
+        if not util.VolatileStorage.contains(f"mal.user.{user_id}"):
             await util.discord.reply(ctx,
                                      embed=discord.Embed(title="You are not yet registered",
                                                          color=discord.Color.orange()))
@@ -169,7 +169,7 @@ class MALNotifier(commands.Cog):
     async def notify_users(self):
         """A method responsible for notifying users if a new manga chapter was released"""
 
-        if not util.VolatileStorage.exists("mal.user"):
+        if not util.VolatileStorage.contains("mal.user"):
             return
 
         for user_id, maluser in util.VolatileStorage["mal.user"].items():
@@ -223,7 +223,7 @@ class MALNotifier(commands.Cog):
         """Import all MALUsers from ``util.PersistentStorage``"""
 
         c = 0
-        if util.PersistentStorage.exists("mal.user"):
+        if util.PersistentStorage.contains("mal.user"):
             for user_id, maluser_json in util.PersistentStorage["mal.user"].items():
                 maluser = MALUser.from_export(int(user_id), maluser_json)
                 maluser.fetch_manga_chapters()

--- a/src/nikobot/util/error.py
+++ b/src/nikobot/util/error.py
@@ -30,7 +30,7 @@ class NoneTypeException(CustomException):
     default_message = "DIdn't expect None as a value here"
 
 class SingletonInstantiation(CustomException):
-    """Exception raised when a singleton classi sinstantiated twice"""
+    """Exception raised when a singleton class is instantiated twice"""
 
     default_message = "The singleton class can only be instantiated once"
 

--- a/src/nikobot/util/storage.py
+++ b/src/nikobot/util/storage.py
@@ -15,7 +15,7 @@ class _BaseStorage():
 
     _store: dict[str, Any] = None
 
-    def contains(self, key: str, item: Any) -> bool:
+    def contains_item(self, key: str, item: Any) -> bool:
         """
         Checks whether a key within the storage contains an item
         If 'key' contains a '.', also checks if all sub-dicts exist
@@ -24,21 +24,21 @@ class _BaseStorage():
         if not isinstance(key, str):
             raise TypeError()
 
-        if not self.exists(key):
+        if not self.contains(key):
             return False
-        return item in self[key]
+        return item == self[key]
 
-    def exists(self, key: str) -> bool:
+    def contains(self, key: str) -> bool:
         """
         Checks whether a key exists within the storage
         If 'key' contains a '.', also checks if all sub-dicts exist
         """
+        # allows checking multi-layer dicts with the following format:
+        # util.PersistentStorage["some_module.some_subdict.another_subdict.key"]
 
         if not isinstance(key, str):
             raise TypeError()
 
-        # allows checking multi-layer dicts with the following format:
-        # util.PersistentStorage["some_module.some_subdict.another_subdict.key"]
         if "." not in key:
             return key in self._store
 
@@ -54,17 +54,23 @@ class _BaseStorage():
         return parts[-1] in curr_dict
 
     def __getitem__(self, key: str) -> Any:
+        # allows getting multi-layer dicts with the following format:
+        # util.PersistentStorage["some_module.some_subdict.another_subdict.key"]
+
         if not isinstance(key, str):
             raise TypeError()
 
-        # allows getting multi-layer dicts with the following format:
-        # util.PersistentStorage["some_module.some_subdict.another_subdict.key"]
         if "." not in key:
+            if key not in self._store:
+                raise error.KeyNotFound("Key not found in storage: " + key)
             return self._store[key]
 
         parts = key.split(".")
         curr_dict = self._store
         for c, part in enumerate(parts):
+            if part not in curr_dict:
+                raise error.KeyNotFound("Key not found in storage: " + 
+                                        ".".join([item if item != part else f"'{item}'" for item in parts]))
             # if it isn't the last part
             if c < len(parts) - 1:
                 curr_dict = curr_dict[part]
@@ -72,55 +78,63 @@ class _BaseStorage():
         return curr_dict[parts[-1]]
 
     def __setitem__(self, key: str, item: Any) -> None:
-        if not isinstance(key, str):
-            raise TypeError()
-
         # allows adding multi-layer dicts with the following format:
         # util.PersistentStorage["some_module.some_subdict.another_subdict.key"] = "value"
-        # items can be accessed using:
-        # util.PersistentStorage["some_module"]["some_subdict"]["another_subdict"]["key"]
-        if "." in key:
-            parts = key.split(".")
-            curr_dict = self._store
-            for c, part in enumerate(parts):
-                # if it isn't the last part
-                if c < len(parts) - 1:
-                    # add a missing dictionary
-                    if part not in curr_dict:
-                        curr_dict[part] = {}
-                    curr_dict = curr_dict[part]
-                else:
-                    # add the actual value
-                    curr_dict[part] = item
-        else:
-            self._store[key] = item
 
-    def __delitem__(self, key: str) -> None:
         if not isinstance(key, str):
             raise TypeError()
 
+        if "." not in key:
+            self._store[key] = item
+            return
+
+        parts = key.split(".")
+        curr_dict = self._store
+        for c, part in enumerate(parts):
+            # if it isn't the last part
+            if c < len(parts) - 1:
+                # add a missing dictionary
+                if part not in curr_dict:
+                    curr_dict[part] = {}
+                curr_dict = curr_dict[part]
+            else:
+                # add the actual value
+                curr_dict[part] = item
+
+    def __delitem__(self, key: str) -> None:
         # items can be removed using:
         # del util.PersistentStorage["some_module"]["some_subdict"]["another_subdict"]["key"]
         # or
         # del util.PersistentStorage["some_module.some_subdict.another_subdict.key"]
-        if "." in key:
-            parts = key.split(".")
-            curr_dict = self._store
-            for c, part in enumerate(parts):
-                # if it isn't the last part
-                if c < len(parts) - 1:
-                    # if a directory is missing, the key definitly doesn't exist
-                    if part not in curr_dict:
-                        return
-                    curr_dict = curr_dict[part]
-                else:
-                    # delete the actual key
-                    del curr_dict[part]
-        else:
+
+        if not isinstance(key, str):
+            raise TypeError()
+
+        if "." not in key:
+            if key not in self._store:
+                raise error.KeyNotFound("Key not found in storage: " + key)
             del self._store[key]
+            return
+
+        parts = key.split(".")
+        curr_dict = self._store
+        for c, part in enumerate(parts):
+            if part not in curr_dict:
+                raise error.KeyNotFound("Key not found in storage: " + 
+                                        ".".join([item if item != part else f"'{item}'" for item in parts]))
+
+            # if it isn't the last part
+            if c < len(parts) - 1:
+                # if a directory is missing, the key definitly doesn't exist
+                if part not in curr_dict:
+                    return
+                curr_dict = curr_dict[part]
+            else:
+                # delete the actual key
+                del curr_dict[part]
 
     def __contains__(self, key: str) -> bool:
-        return key in self._store
+        return self.contains(key)
 
     def __str__(self) -> str:
         return str(self._store)
@@ -152,10 +166,10 @@ class _PersistentStorage(_BaseStorage):
         return super().__setitem__(key, item)
 
     def _load_from_disk(self) -> None:
-        if "storage_file" not in VolatileStorage:
+        if "storage_file" not in self:
             raise error.KeyNotFound()
 
-        path = VolatileStorage["storage_file"]
+        path = self["storage_file"]
         if not os.path.isfile(path):
             print("Storage file doesn't yet exist")
             return
@@ -164,10 +178,10 @@ class _PersistentStorage(_BaseStorage):
             self._store = json.load(f)
 
     def _save_to_disk(self) -> None:
-        if "storage_file" not in VolatileStorage:
+        if "storage_file" not in self:
             raise error.KeyNotFound()
 
-        path = VolatileStorage["storage_file"]
+        path = self["storage_file"]
         if len(self._store) == 0 and os.path.isfile(path):
             print("Not overwriting existing storage file with empty storage")
             return
@@ -175,8 +189,38 @@ class _PersistentStorage(_BaseStorage):
         with open(path, "w", encoding="utf8") as f:
             json.dump(self._store, f)
 
+class _StorageView():
+    """A read-only view on both the PersistentStorage and VolatileStorage"""
+
+    def contains_item(self, key: str, item: Any) -> bool:
+        """
+        Checks whether a key within the storage contains an item
+        If 'key' contains a '.', also checks if all sub-dicts exist
+        """
+
+        return PersistentStorage.contains_item(key, item) \
+               or VolatileStorage.contains_item(key, item)
+
+    def contains(self, key: str) -> bool:
+        """
+        Checks whether a key exists within the storage
+        If 'key' contains a '.', also checks if all sub-dicts exist
+        """
+
+        return PersistentStorage.contains(key) \
+               or VolatileStorage.contains(key)
+
+    def __getitem__(self, key: str) -> Any:
+        if key in PersistentStorage:
+            return PersistentStorage[key]
+        return VolatileStorage[key]
+
+    def __contains__(self, key: str) -> bool:
+        return self.contains(key)
+
 VolatileStorage = _VolatileStorage()
 PersistentStorage = _PersistentStorage()
+StorageView = _StorageView()
 
 # save persistent storage before program exits
 # pylint: disable-next=protected-access

--- a/src/nikobot/util/storage.py
+++ b/src/nikobot/util/storage.py
@@ -69,7 +69,7 @@ class _BaseStorage():
         curr_dict = self._store
         for c, part in enumerate(parts):
             if part not in curr_dict:
-                raise error.KeyNotFound("Key not found in storage: " + 
+                raise error.KeyNotFound("Key not found in storage: " +
                                         ".".join([item if item != part else f"'{item}'" for item in parts]))
             # if it isn't the last part
             if c < len(parts) - 1:
@@ -120,7 +120,7 @@ class _BaseStorage():
         curr_dict = self._store
         for c, part in enumerate(parts):
             if part not in curr_dict:
-                raise error.KeyNotFound("Key not found in storage: " + 
+                raise error.KeyNotFound("Key not found in storage: " +
                                         ".".join([item if item != part else f"'{item}'" for item in parts]))
 
             # if it isn't the last part


### PR DESCRIPTION
This pull request includes:
* Slightly rework the storages' logic
* Rename Storage.contains to Storage.contains_item
* Rename Storage.exists to Storage.contains
* Add StorageView, which is a read-only singleton class which reads from both the PersistentStorage and VolatileStorage. This eliminates the need to remember where items such as the DiscordBot instance or storage_file are stored for read access.