### PR TITLE
Rework hybrid commands

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,7 +30,8 @@ disable=too-many-arguments,
         relative-beyond-top-level,
         too-many-positional-arguments,
         logging-fstring-interpolation,
-        logging-not-lazy
+        logging-not-lazy,
+        too-many-branches
 
 [FORMAT]
 

--- a/src/nikobot/discord_bot.py
+++ b/src/nikobot/discord_bot.py
@@ -63,7 +63,7 @@ class DiscordBot(commands.Bot):
                 await context.message.reply(embed=answer)
                 return
 
-            embed = discordpy.Embed(title=f"Command '{user_command}' not found!\n")
+            embed = discordpy.Embed(title=f"Command '{user_command}' not found!", color=discordpy.Color.red())
 
             cmds: list[tuple[commands.Command, int]] = []
             for cmd in self.commands:
@@ -80,6 +80,18 @@ class DiscordBot(commands.Bot):
 
             await discord.reply(context, embed=embed)
             return
+        
+        # command was misused by the user
+        if isinstance(exception, commands.errors.UserInputError):
+            if isinstance(exception, commands.MissingRequiredArgument):
+                required_arg: str = exception.args[0].split(' ', maxsplit=1)[0]
+                embed = discordpy.Embed(title=f"Missing required argument '{required_arg}'!", color=discordpy.Color.red())
+                await discord.reply(context, embed=embed)
+                return
+            if isinstance(exception, commands.TooManyArguments):
+                embed = discordpy.Embed(title=f"Too many arguments!", color=discordpy.Color.red())
+                await discord.reply(context, embed=embed)
+                return
 
         # all other commands
         # code from https://stackoverflow.com/a/73706008/15436169

--- a/src/nikobot/discord_bot.py
+++ b/src/nikobot/discord_bot.py
@@ -80,16 +80,17 @@ class DiscordBot(commands.Bot):
 
             await discord.reply(context, embed=embed)
             return
-        
+
         # command was misused by the user
         if isinstance(exception, commands.errors.UserInputError):
             if isinstance(exception, commands.MissingRequiredArgument):
                 required_arg: str = exception.args[0].split(' ', maxsplit=1)[0]
-                embed = discordpy.Embed(title=f"Missing required argument '{required_arg}'!", color=discordpy.Color.red())
+                embed = discordpy.Embed(title=f"Missing required argument '{required_arg}'!",
+                                        color=discordpy.Color.red())
                 await discord.reply(context, embed=embed)
                 return
             if isinstance(exception, commands.TooManyArguments):
-                embed = discordpy.Embed(title=f"Too many arguments!", color=discordpy.Color.red())
+                embed = discordpy.Embed(title="Too many arguments!", color=discordpy.Color.red())
                 await discord.reply(context, embed=embed)
                 return
 
@@ -102,6 +103,7 @@ class DiscordBot(commands.Bot):
                     + f"```py\n{''.join(full_error[:1500])}\n```"
             await discord.private_message(discord.get_owner_id(),
                                             msg_text)
+        # pylint: disable-next=broad-exception-caught
         except Exception:
             logger.warning("Couldn't notify owner about command error!")
 

--- a/src/nikobot/discord_bot.py
+++ b/src/nikobot/discord_bot.py
@@ -83,12 +83,16 @@ class DiscordBot(commands.Bot):
 
         # all other commands
         # code from https://stackoverflow.com/a/73706008/15436169
-        user = await discord.get_bot().fetch_user(discord.get_user_id(context))
-        full_error = traceback.format_exception(exception)
-        msg_text = f"User {user} used command {discord.get_command_name(context)}:\n" \
-                   + f"```py\n{''.join(full_error)}\n```"
-        await discord.private_message(discord.get_owner_id(),
-                                           msg_text)
+        try:
+            user = await discord.get_bot().fetch_user(discord.get_user_id(context))
+            full_error = traceback.format_exception(exception)
+            msg_text = f"User {user} used command {discord.get_command_name(context)}:\n" \
+                    + f"```py\n{''.join(full_error[:1500])}\n```"
+            await discord.private_message(discord.get_owner_id(),
+                                            msg_text)
+        except Exception:
+            logger.warning("Couldn't notify owner about command error!")
+
         embed = discordpy.Embed(title="An error occured!",
                               color=discordpy.Color.red())
         message = await discord.get_reply(context)

--- a/src/nikobot/modules/avatar.py
+++ b/src/nikobot/modules/avatar.py
@@ -1,5 +1,6 @@
 """A module containing the avatar command"""
 
+import logging
 import os
 import pathlib
 
@@ -8,6 +9,8 @@ import requests
 from discord.ext import commands
 
 from .. import util
+
+logger = logging.getLogger("avatar")
 
 class Avatar(commands.Cog):
     """A ``discord.commands.Cog`` containing the avatar command"""
@@ -19,12 +22,12 @@ class Avatar(commands.Cog):
         "avatar",
         "Send back the mentioned users avatar"
     )
-    async def avatar(self, ctx: commands.context.Context | discordpy.interactions.Interaction, *user: list[str]):
+    async def avatar(self, ctx: commands.context.Context | discordpy.interactions.Interaction, user: str):
         """Send back the mentioned users avatar"""
 
-        recombined_user = " ".join(["".join(item) for item in user])
+        logger.debug(f"Searching for avatar of user {user}")
 
-        user_obj: discordpy.member.Member | None = await util.discord.parse_user(ctx, recombined_user)
+        user_obj: discordpy.member.Member | None = await util.discord.parse_user(ctx, user)
         if user_obj is None:
             await util.discord.reply(ctx, "User could not be found!")
             return

--- a/src/nikobot/modules/general.py
+++ b/src/nikobot/modules/general.py
@@ -1,6 +1,9 @@
 """A module containing general commands"""
 
+from discord import Embed
 from discord.ext import commands
+
+from nikobot.util import discord
 
 class General(commands.Cog):
     """A ``discord.commands.Cog`` containing general commands"""
@@ -17,6 +20,33 @@ class General(commands.Cog):
         """
 
         await ctx.send("UwU")
+
+    @discord.normal_command("printall", "print all given args in order", hidden=True)
+    async def printall(self,
+                       ctx: commands.context.Context,
+                       arg1: str | None = None,
+                       arg2: str | None = None,
+                       arg3: str | None = None,
+                       arg4: str | None = None,
+                       arg5: str | None = None):
+        """
+        Print all given arguments
+        
+        This command is used for debugging
+        """
+
+        embed = Embed(title="All given arguments:")
+        if arg1 is not None:
+            embed.add_field(name="arg1", value=arg1)
+        if arg2 is not None:
+            embed.add_field(name="arg2", value=arg2)
+        if arg3 is not None:
+            embed.add_field(name="arg3", value=arg3)
+        if arg4 is not None:
+            embed.add_field(name="arg4", value=arg4)
+        if arg5 is not None:
+            embed.add_field(name="arg5", value=arg5)
+        await discord.reply(ctx, embed=embed)
 
 async def setup(bot: commands.Bot):
     """Setup the bot_commands cog"""

--- a/src/nikobot/modules/mal/malnotifier.py
+++ b/src/nikobot/modules/mal/malnotifier.py
@@ -35,15 +35,13 @@ class MALNotifier(commands.Cog):
             description="Search for a manga on MyAnimeList",
             command_group=command_group
     )
-    async def manga(self, ctx: commands.context.Context | discordpy.interactions.Interaction, *title: list[str]):
+    async def manga(self, ctx: commands.context.Context | discordpy.interactions.Interaction, title: str):
         """The discord command 'niko.mal.manga'"""
 
-        recombined_title = " ".join(["".join(item) for item in title])
-
-        if recombined_title.isdecimal():
-            mal_id = int(recombined_title)
+        if title.isdecimal():
+            mal_id = int(title)
         else:
-            mal_id = mal_helper.search_for_manga(recombined_title)
+            mal_id = mal_helper.search_for_manga(title)
             if mal_id is None:
                 await util.discord.reply(ctx,
                                         embed=discordpy.Embed(title="Manga not found on MyAnimeList",

--- a/src/nikobot/modules/tc4/tc4.py
+++ b/src/nikobot/modules/tc4/tc4.py
@@ -61,7 +61,7 @@ class TC4(commands.Cog):
     async def path(self, ctx: commands.context.Context, aspect_name_1: str, aspect_name_2: str):
         """The shortest path between two aspects"""
 
-        logger.info(f"Calculating path between {aspect_name_1} and {aspect_name_2}")
+        logger.debug(f"Calculating path between {aspect_name_1} and {aspect_name_2}")
 
         aspect_objs = [self._find_aspect(aspect_name_1), self._find_aspect(aspect_name_2)]
         if aspect_objs[0] is None:

--- a/src/nikobot/modules/tc4/tc4.py
+++ b/src/nikobot/modules/tc4/tc4.py
@@ -61,6 +61,8 @@ class TC4(commands.Cog):
     async def path(self, ctx: commands.context.Context, aspect_name_1: str, aspect_name_2: str):
         """The shortest path between two aspects"""
 
+        logger.info(f"Calculating path between {aspect_name_1} and {aspect_name_2}")
+
         aspect_objs = [self._find_aspect(aspect_name_1), self._find_aspect(aspect_name_2)]
         if aspect_objs[0] is None:
             await util.discord.reply(ctx, f"The aspect {aspect_name_1} wasn't found!")

--- a/src/nikobot/util/error.py
+++ b/src/nikobot/util/error.py
@@ -1,5 +1,7 @@
 """Custom esceptions for general usage"""
 
+from discord.ext import commands
+
 class CustomException(Exception):
     """The base class for all custom exceptions"""
 
@@ -38,3 +40,9 @@ class UserNotFound(CustomException):
     """Exception raised when the discord user wasn't found"""
 
     default_message = "The discord user couldn't be found"
+
+class MissingRequiredArgument(commands.MissingRequiredArgument):
+    """Exception raised when a command was called without a required argument"""
+
+class TooManyArguments(commands.TooManyArguments):
+    """Exception raised when a command was called with too many arguments"""


### PR DESCRIPTION
This PR reworks hybrid commands to allow for more flexibility when using string arguments in commands.

Breaking change: defining a string argument as 
```py
async def my_command(self, ctx, *my_arg: list[str]):
    my_arg_combined = " ".join(["".join(item) for item in my_arg])
```
is no longer allowed, please use
```py
async def my_command(self, ctx, my_arg: str):
    pass
```
instead. The functionality will be the same. This also supports string inputs with whitespaces. 