### PR TITLE
Check if help cog is loaded before calling help command

### DIFF
--- a/src/nikobot/discord_bot.py
+++ b/src/nikobot/discord_bot.py
@@ -56,7 +56,7 @@ class DiscordBot(commands.Bot):
             user_command: str = exception.args[0].split('"')[1]
 
             # call help command if command ends with '.help'
-            if user_command.endswith(".help"):
+            if discord.is_cog_loaded("help") and user_command.endswith(".help"):
                 help_cog = self.cogs["Help"]
                 # pylint: disable-next=protected-access
                 answer = help_cog._generate_help_specific_normal(user_command.replace(".help", ""))

--- a/src/nikobot/util/discord.py
+++ b/src/nikobot/util/discord.py
@@ -431,6 +431,11 @@ def _remove_type_hints(signature: str) -> str:
 
     return ", ".join(args)
 
+def is_cog_loaded(name: str) -> bool:
+    """Checks whether the cog with the given name is loaded"""
+
+    return name.lower() in (cog.lower() for cog in get_bot().cogs)
+
 def is_private_channel(ctx: commands.context.Context | discordpy.interactions.Interaction) -> bool:
     """Checks whether the message related to ``ctx`` was received as a private / direct message"""
 


### PR DESCRIPTION
Fixes a minor bug that occurred if a command isn't found and the help cog isn't loaded.